### PR TITLE
Remove unused requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pyrax>=1.9.2
 lavaclient==0.2.1


### PR DESCRIPTION
Duplicate and unused requirement can cause build errors in our CI/CD